### PR TITLE
Add 10 minute timeout for lint-build-deploy

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -29,10 +29,10 @@ jobs:
         run: npm run lint
 
       - name: build
-        run: npm run build
+        run: npm run build -- -c=production
 
       - name: scully-build
-        run: npm run scully
+        run: npm run scully -- --prod
 
       - name: deploy-to-ghpages
         # only execute if on main branch

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -8,7 +8,8 @@ on:
       - '*.*'
 
 jobs:
-  lint-and-build:
+  lint-build-deploy:
+    timeout-minutes: 10
     name: lint test and build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- should prevent unnecessarily long job time.