### PR TITLE
Chore/186/remove tracking from ci

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -52,16 +52,17 @@ jobs:
       - name: scully-build
         run: npx nx run client:scully:prod
 
-      - name: run e2e
-        run: npx nx run client-e2e:e2e --headless
+      # skip this for now, as we don't even have tests.
+      # - name: run e2e
+      #   run: npx nx run client-e2e:e2e --headless
 
-      - name: Upload cypress files
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-dist
-          path: dist/cypress
-          retention-days: 5
+      # - name: Upload cypress files
+      #   uses: actions/upload-artifact@v2
+      #   if: failure()
+      #   with:
+      #     name: cypress-dist
+      #     path: dist/cypress
+      #     retention-days: 5
 
       - name: run-lighthouse-ci
         uses: treosh/lighthouse-ci-action@v7

--- a/apps/client-e2e/cypress.json
+++ b/apps/client-e2e/cypress.json
@@ -8,5 +8,6 @@
   "video": true,
   "videosFolder": "../../dist/cypress/apps/client-e2e/videos",
   "screenshotsFolder": "../../dist/cypress/apps/client-e2e/screenshots",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "blockHosts": "*.google-analytics.com"
 }

--- a/apps/client/src/environments/environment ci.ts
+++ b/apps/client/src/environments/environment ci.ts
@@ -1,0 +1,9 @@
+import { environment as prodEnvironment } from './environment.prod';
+/**
+ * This environment is used just for ci/cd flows,
+ * and is based off of the production config
+ */
+export const environment = {
+  ...prodEnvironment,
+  gtagCode: '', // don't use analytics
+};

--- a/workspace.json
+++ b/workspace.json
@@ -70,6 +70,27 @@
               ],
               "outputHashing": "all"
             },
+            "ci": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "1mb",
+                  "maximumError": "2mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "40kb",
+                  "maximumError": "50kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "apps/client/src/environments/environment.ts",
+                  "with": "apps/client/src/environments/environment.ci.ts"
+                }
+              ],
+              "outputHashing": "all"
+            },
             "development": {
               "buildOptimizer": false,
               "optimization": false,


### PR DESCRIPTION
- Add ci configuration, not used
- Add google-anlytics as blocked hosts during cypress runs, not used
- Remove cypress execution from pipeline, as we have no tests.

Closes #186